### PR TITLE
Refactor method complexity

### DIFF
--- a/batnode.js
+++ b/batnode.js
@@ -244,13 +244,14 @@ class BatNode {
             const saveShardAs = distinctShards[distinctIdx]
             this.sendPaymentFor(accountId, (paymentResult) => {
               this.retrieveSingleShard(currentCopy, hostBatNode, null, (data) => {
-                fs.writeFileSync(`./shards/${saveShardAs}`, data, 'utf8')
-                if (distinctIdx < distinctShards.length - 1){
-                  this.iterativeRetrieveSingleCopy(distinctShards, allShards, fileName, manifestFilePath, distinctIdx + 1, copyIdx)
-                } else {
-                  fileUtils.assembleShards(fileName, distinctShards)
-                  console.log("You have successfully downloaded the file")
-                }
+                fs.writeFile(`./shards/${saveShardAs}`, data, {encoding:'utf8'}, () => {
+                  if (distinctIdx < distinctShards.length - 1){
+                    this.iterativeRetrieveSingleCopy(distinctShards, allShards, fileName, manifestFilePath, distinctIdx + 1, copyIdx)
+                  } else {
+                    fileUtils.assembleShards(fileName, distinctShards)
+                    console.log("You have successfully downloaded the file")
+                  }
+                })
               })
             });
           });
@@ -260,6 +261,7 @@ class BatNode {
       this.getHostNode(currentCopy, afterHostNodeIsFound)
     }
   }
+
   retrieveSingleShard(shardId, hostBatNode, finishCallback, dataCallback){
     let client = this.connect(hostBatNode.port, hostBatNode.host, () => {
       let message = {
@@ -286,6 +288,7 @@ class BatNode {
       callback(data)
     })
   }
+
   getHostNode(shardId, callback){
     this.kadenceNode.iterativeFindValue(shardId, (error, value, responder) => {
       if (error) { throw error; }

--- a/batnode.js
+++ b/batnode.js
@@ -260,28 +260,6 @@ class BatNode {
       this.getHostNode(currentCopy, afterHostNodeIsFound)
     }
   }
-
-  issueRetrieveShardRequest(shardId, hostBatNode, options, finishCallback, dataCallback){
-   let { saveShardAs, distinctIdx, distinctShards, fileName } = options
-   let client = this.connect(hostBatNode.port, hostBatNode.host, () => {
-    let message = {
-      messageType: 'RETRIEVE_FILE',
-      fileName: shardId
-    }
-
-    client.on('data', (data) => {
-      fs.writeFileSync(`./shards/${saveShardAs}`, data, 'utf8')
-      if (distinctIdx < distinctShards.length - 1){
-        finishCallback()
-      } else {
-        fileUtils.assembleShards(fileName, distinctShards)
-        console.log("You have successfully downloaded the file")
-      }
-    })
-    client.write(JSON.stringify(message))
-   })
-  }
-
   retrieveSingleShard(shardId, hostBatNode, finishCallback, dataCallback){
     let client = this.connect(hostBatNode.port, hostBatNode.host, () => {
       let message = {

--- a/batnode.js
+++ b/batnode.js
@@ -292,6 +292,7 @@ class BatNode {
       client.on('data', (data) => {
         finishCallback(data)
       })
+      client.write(JSON.stringify(message))
     })
   }
 

--- a/batnode.js
+++ b/batnode.js
@@ -487,7 +487,7 @@ class BatNode {
         console.log("Error: Patch failed because a previously live node on the network has disconnected. Try to patch again!")
       } else {
         this.retrieveSingleShard(siblingShardId, batNode, (shardData) => {
-          console.log('retrieved shard, ' shardData.toString(), '\n')
+          console.log('retrieved shard, ', shardData.toString(), '\n')
           const newShardId = fileUtils.createRandomShardId(shardData);
           this.getClosestBatNodeToShard(newShardId, (closestBatNode, closeKadNode) => {
             console.log("retrieved closest BatNode",closestBatNode, '\n' )

--- a/batnode.js
+++ b/batnode.js
@@ -126,31 +126,33 @@ class BatNode {
       console.log('connected to target batnode')
     });
 
-    let message = {
-      messageType: "STORE_FILE",
-      fileName: shard,
-      fileContent: fs.readFileSync(`./shards/${storedShardName}`)
-    };
-
-    client.on('data', (data) => {
-      console.log("Shard successfully stored on server!")
-      if (shardIdx < shards.length - 1){
-        this.getClosestBatNodeToShard(shards[shardIdx + 1], (batNode, kadNode) => {
-          this.kadenceNode.getOtherNodeStellarAccount(kadNode, (error, accountId) => {
-            console.log("Sending payment to a peer node's Stellar account...")
-            this.sendPaymentFor(accountId, (paymentResult) => {
-              this.sendShardToNode(batNode, shards[shardIdx + 1], shards, shardIdx + 1, storedShardName, distinctIdx, manifestPath)
+    fs.readFile(`./shards/${storedShardName}`, (fileData) => {
+      let message = {
+        messageType: "STORE_FILE",
+        fileName: shard,
+        fileContent: fileData
+      };
+  
+      client.on('data', (data) => {
+        console.log("Shard successfully stored on server!")
+        if (shardIdx < shards.length - 1){
+          this.getClosestBatNodeToShard(shards[shardIdx + 1], (batNode, kadNode) => {
+            this.kadenceNode.getOtherNodeStellarAccount(kadNode, (error, accountId) => {
+              console.log("Sending payment to a peer node's Stellar account...")
+              this.sendPaymentFor(accountId, (paymentResult) => {
+                this.sendShardToNode(batNode, shards[shardIdx + 1], shards, shardIdx + 1, storedShardName, distinctIdx, manifestPath)
+              })
             })
           })
-        })
-      } else {
-        this.distributeCopies(distinctIdx + 1, manifestPath)
-      }
+        } else {
+          this.distributeCopies(distinctIdx + 1, manifestPath)
+        }
+      })
+  
+      client.write(JSON.stringify(message), () => {
+        console.log('Sending shard to a peer node...')
+      });
     })
-
-    client.write(JSON.stringify(message), () => {
-      console.log('Sending shard to a peer node...')
-    });
   }
 
   // Upload file will process the file then send it to the target node

--- a/batnode.js
+++ b/batnode.js
@@ -243,7 +243,7 @@ class BatNode {
           this.kadenceNode.getOtherNodeStellarAccount(kadNode, (error, accountId) => {
             const saveShardAs = distinctShards[distinctIdx]
             this.sendPaymentFor(accountId, (paymentResult) => {
-              this.issueRetrieveShardRequest(currentCopy, hostBatNode, null, (data) => {
+              this.retrieveSingleShard(currentCopy, hostBatNode, null, (data) => {
                 fs.writeFileSync(`./shards/${saveShardAs}`, data, 'utf8')
                 if (distinctIdx < distinctShards.length - 1){
                   this.iterativeRetrieveSingleCopy(distinctShards, allShards, fileName, manifestFilePath, distinctIdx + 1, copyIdx)

--- a/batnode.js
+++ b/batnode.js
@@ -296,7 +296,7 @@ class BatNode {
     })
   }
 
-  sendStoreMessage(shardId, shardData, targetNode, callback){
+  sendStoreMessageFor(shardId, shardData, targetNode, callback){
     let storeClient = this.connect(targetNode.port, targetNode.host)
     let storeMessage = {
       messageType: "STORE_FILE",

--- a/batnode.js
+++ b/batnode.js
@@ -487,12 +487,16 @@ class BatNode {
         console.log("Error: Patch failed because a previously live node on the network has disconnected. Try to patch again!")
       } else {
         this.retrieveSingleShard(siblingShardId, batNode, (shardData) => {
+          console.log('retrieved shard, ' shardData.toString(), '\n')
           const newShardId = fileUtils.createRandomShardId(shardData);
-          this.getClosestBatNodeToShard(newShardId, (closestBatNode, kadNode) => {
-            this.kadenceNode.getOtherNodeStellarAccount(kadNode, (error, accountId) => {
+          this.getClosestBatNodeToShard(newShardId, (closestBatNode, closeKadNode) => {
+            console.log("retrieved closest BatNode",closestBatNode, '\n' )
+            this.kadenceNode.getOtherNodeStellarAccount(closeKadNode, (error, accountId) => {
+              console.log('retrieved account id ', accountId, '\n')
               if (error) {throw error}
               this.sendPaymentFor(accountId, () => {
                 this.sendStoreMessageFor(newShardId, shardData, closestBatNode, () => {
+                  console.log('sendStoreMessageSent')
                   this.cleanUpManifest(failedShaId, copiesToRemoveFromManifest, manifestPath, newShardId)
                 })
               })

--- a/batnode.js
+++ b/batnode.js
@@ -476,6 +476,7 @@ class BatNode {
 
   patchFile(manifestPath, failedShaId, siblingShardId, copiesToRemoveFromManifest) {
 
+    console.log('patch file called')
     // Get siblingShardData
     // Generate new id with sibling shard data
     // Find node on the network with closest id to new shard id


### PR DESCRIPTION
Changes:

1. Removed `sendShardRequest` method entirely
2. Refactored methods to use non-thread blocking, asynchronous IO
3. refactor auditResults to add all failed shards to `batNode.failed`
4. Refactor `pathFile` by extracting logic to external methods